### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,12 @@
             <div class="span12">
 <!-- Page content. -->
 <ul class="breadcrumb">
-    <li><a href="https://diecutter.readthedocs.org">diecutter, templates as a service</a> <span class="divider">/</span></li>
+    <li><a href="https://diecutter.readthedocs.io">diecutter, templates as a service</a> <span class="divider">/</span></li>
 </ul> 
 <h1>Welcome to the DIECUTTER index!</h1>
 <p>
     <strong>So you heard about
-    <a href="https://diecutter.readthedocs.org">diecutter</a>?
+    <a href="https://diecutter.readthedocs.io">diecutter</a>?
     Let's give it a try!</strong>
 </p>
 
@@ -36,7 +36,7 @@
     <li>
         But you can also use curl, wget or any HTTP client!
         Learn more about
-        <a href="https://diecutter.readthedocs.org/en/latest/client/index.html">
+        <a href="https://diecutter.readthedocs.io/en/latest/client/index.html">
             diecutter's API usage
         </a> in the project's documentation.
     </li>
@@ -59,7 +59,7 @@
     templates as a service.
 </p>
 <ul>
-    <li><a href="http://diecutter.readthedocs.org">Documentation</a></li>
+    <li><a href="https://diecutter.readthedocs.io">Documentation</a></li>
     <li><a href="http://pypi.python.org/pypi/diecutter">PyPI page</a></li>
     <li><a href="https://github.com/diecutter/diecutter">Code repository</a></li>
     <li><a href="https://github.com/diecutter/diecutter/issues">Bugtracker</a></li>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
